### PR TITLE
Add rescue_from to return non-HTML responses for 404 errors.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,4 +15,9 @@ class ApplicationController < ActionController::Base
         status: :unauthorized
     end
   end
+
+  rescue_from ActiveRecord::RecordNotFound do |error|
+    render json: { error: "Could not find object: #{error.message}" },
+      status: :not_found
+  end
 end


### PR DESCRIPTION
You don't want to hit API users with HTML do you?
